### PR TITLE
use only requirements_docs.txt in readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,8 +11,6 @@ sphinx:
 
 python:
   install:
-    - method: pip
-      path: .
     - requirements: requirements_docs.txt
 
 build:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,8 @@ sphinx:
 
 python:
   install:
+    - method: pip
+      path: .
     - requirements: requirements_docs.txt
 
 build:

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ It has been released on GitHub "as is" for anyone wanting to see the code that h
 Install
 -------
 
-You will not be able to install this software, unless you have access to the private software 'bluepy'.
-If you have it installed, you can install this software by cloning this repository locally using
+You will not be able to install this software, unless you have access to the private software 'bluepy' and 'bluepy-configfile'.
+If you have them installed, you can install this software by cloning this repository locally using
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Install
 -------
 
 You will not be able to install this software, unless you have access to the private software 'bluepy'.
-If you have it, you can install this software by cloning this repository locally using
+If you have it installed, you can install this software by cloning this repository locally using
 
 .. code-block:: console
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,7 +66,7 @@ extensions = [
 exclude_patterns = []
 
 
-autodoc_mock_imports = ["bluepy", "bglibpy", "glusynapseutils", "bluepy-configfile"]
+autodoc_mock_imports = ["bluepy", "bglibpy", "glusynapseutils", "bluepy_configfile"]
 
 # autosummary settings
 autosummary_generate = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -66,7 +66,7 @@ extensions = [
 exclude_patterns = []
 
 
-autodoc_mock_imports = ["bluepy", "bglibpy", "glusynapseutils"]
+autodoc_mock_imports = ["bluepy", "bglibpy", "glusynapseutils", "bluepy-configfile"]
 
 # autosummary settings
 autosummary_generate = True

--- a/e_model_packager/version.py
+++ b/e_model_packager/version.py
@@ -16,5 +16,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-VERSION = "0.3.1.dev4"
+VERSION = "0.3.1.dev5"
 __version__ = VERSION

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -15,3 +15,15 @@
 
 sphinx>=2.0.0
 sphinx-bluebrain-theme
+luigi
+numpy
+bluepyopt>=1.13.168
+pandas
+pynwb >= 2.0.0
+EModelRunner>=1.1.9
+luigi-tools>=0.0.6
+h5py
+efel
+schema
+click>=8.0.0
+bluecellulab

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -15,15 +15,3 @@
 
 sphinx>=2.0.0
 sphinx-bluebrain-theme
-luigi
-numpy
-bluepyopt>=1.13.168
-pandas
-pynwb >= 2.0.0
-EModelRunner>=1.1.9
-luigi-tools>=0.0.6
-h5py
-efel
-schema
-click>=8.0.0
-bluecellulab

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,16 +1,16 @@
-// Copyright 2024 Blue Brain Project / EPFL
+# Copyright 2024 Blue Brain Project / EPFL
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-//     http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 sphinx>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ EXTRA_GLUSYNAPSE = [
     "numpy<1.24",  # RNG are changed for numpy>=1.24
     "bglibpy==4.4.51",  # not open-sourced
     "glusynapseutils",  # not open-sourced
-    "bluepy-configfile>=0.1.21", # not open-sourced
+    "bluepy-configfile>=0.1.21",  # not open-sourced
 ]
 
 EXTRA_SSCX_THALAMUS = [
     "bluepy>=v2.3.0",  # not open-sourced: this is NOT the bluepy package available on PyPi
-    "bluepy-configfile>=0.1.21", # not open-sourced
+    "bluepy-configfile>=0.1.21",  # not open-sourced
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,12 @@ EXTRA_GLUSYNAPSE = [
     "numpy<1.24",  # RNG are changed for numpy>=1.24
     "bglibpy==4.4.51",  # not open-sourced
     "glusynapseutils",  # not open-sourced
+    "bluepy-configfile>=0.1.21", # not open-sourced
 ]
 
 EXTRA_SSCX_THALAMUS = [
     "bluepy>=v2.3.0",  # not open-sourced: this is NOT the bluepy package available on PyPi
+    "bluepy-configfile>=0.1.21", # not open-sourced
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,10 @@ EXTRA_GLUSYNAPSE = [
     "glusynapseutils",  # not open-sourced
 ]
 
+EXTRA_SSCX_THALAMUS = [
+    "bluepy>=v2.3.0",  # not open-sourced: this is NOT the bluepy package available on PyPi
+]
+
 setup(
     name="e-model-packager",
     version=VERSION,
@@ -37,7 +41,6 @@ setup(
     install_requires=[
         "luigi",
         "numpy",
-        "bluepy>=v2.3.0",  # not open-sourced: this is NOT the bluepy package available on PyPi
         "bluepyopt>=1.13.168",
         "pandas",
         "pynwb >= 2.0.0",
@@ -51,6 +54,8 @@ setup(
     ],
     extras_require={
         "glusynapse": EXTRA_GLUSYNAPSE,
+        "sscx": EXTRA_SSCX_THALAMUS,
+        "thalamus": EXTRA_SSCX_THALAMUS,
     },
     packages=find_packages(),
     python_requires=">=3.8",


### PR DESCRIPTION
Motivation: missing private bluepy dependency is preventing us from installing in readthedocs. Installing dependencies from custom readthedocs file, while having mock imports in the conf.py should hopefully allow us to install and run sphinx in readthedocs